### PR TITLE
Tweak rust linker flags

### DIFF
--- a/native/ketbin_utils_syntax/.cargo/config
+++ b/native/ketbin_utils_syntax/.cargo/config
@@ -1,4 +1,4 @@
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",


### PR DESCRIPTION
To also support Macs with Apple's ARM Chip in them.
See rusterlium/rustler#340 for details.